### PR TITLE
Added a new feature that allows for file based locking. The purpose

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -23,6 +23,10 @@
 #include "script.h"
 #include "masscan-app.h"
 
+#if defined(__linux__)
+#include "posix-lock.h"
+#endif
+
 #include <ctype.h>
 #include <limits.h>
 
@@ -447,6 +451,10 @@ masscan_echo(struct Masscan *masscan, FILE *fp)
     fprintf(fp, "%scapture = html\n", masscan->is_capture_html?"":"no");
     fprintf(fp, "%scapture = heartbleed\n", masscan->is_capture_heartbleed?"":"no");
 
+#if defined(__linux__) && defined(__GNUC__)
+    if (masscan->lockfile)
+        fprintf(fp,"lockfile = %s\n", masscan->lockfile);
+#endif
     /*
      *  TCP payloads
      */
@@ -1311,7 +1319,16 @@ masscan_set_parameter(struct Masscan *masscan,
     } else if (EQUALS("ip-options", name)) {
         fprintf(stderr, "nmap(%s): unsupported: maybe soon\n", name);
         exit(1);
-    } else if (EQUALS("log-errors", name)) {
+    }
+#if defined(__linux__)
+    else if (EQUALS("lockfile",name)) {
+        /* Get a lock on an existing file, a failsafe for programmatic use of masscan */
+        /* acquire_posix_lock() will exit if it fails so no return check is necessary */
+        masscan->lockfile = (unsigned char *)strdup(value);
+        acquire_posix_lock(value);
+    } 
+#endif
+    else if (EQUALS("log-errors", name)) {
         fprintf(stderr, "nmap(%s): unsupported: maybe soon\n", name);
         exit(1);
     } else if (EQUALS("min-packet", name) || EQUALS("min-pkt", name)) {
@@ -1875,6 +1892,20 @@ masscan_command_line(struct Masscan *masscan, int argc, char *argv[])
                     masscan_set_parameter(masscan, "adapter", arg);
                 }
                 break;
+#if defined(__linux__)
+            case 'l':
+                /* Acquire lock on file, exit on fail */
+                if (argv[i][2])
+                    arg = argv[i]+2;
+                else
+                    arg = argv[++i];
+                /* 
+                 * this will short-circuit command line parsing, which might be annoying
+                 * when using --echo
+                 */
+                masscan_set_parameter(masscan, "lockfile", arg);
+                break;
+#endif
             case 'n':
                 /* This looks like an nmap option*/
                 /* Do nothing: this code never does DNS lookups anyway */

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -345,6 +345,9 @@ struct Masscan
     unsigned char *http_user_agent;
     unsigned http_user_agent_length;
     unsigned tcp_connection_timeout;
+#if defined(__linux__)
+    unsigned char *lockfile;
+#endif
     
     /** Number of seconds to wait for a 'hello' from the server before
      * giving up and sending a 'hello' from the client. Should be a small

--- a/src/posix-lock.c
+++ b/src/posix-lock.c
@@ -1,0 +1,78 @@
+#if defined(__linux__)
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <string.h>
+#include "posix-lock.h"
+#include "logger.h"
+
+/* 
+  Lock a file or die, to provide assurance that a 'scan manager' won't 
+  melt your LAN
+
+  Here, 'scan manager' means some automated script or application that 
+  invokes masscan infinitely in a serial fashion, rather than using the
+  masscan infinite flag. 
+
+  This feature is designed to prevent a buggy or broken scan manager from 
+  invoking the same masscan instance more than once. This can happen if it 
+  fails (i.e. crashes) and doesn't clean up the child masscan process, and
+  doesn't go through all the trouble of checking the process list to try
+  and find the process. Relying on a PID file isn't always reliable when
+  things crash.
+
+  Yes, fix the scan manager so that it doesn't crash, or makes sure its
+  children are cleaned up somehow, but for networks that can't handle certain 
+  packet rates, this is a failsafe to prevent the possibility of affecting 
+  production networks/systems that can't handle multiple scans at once. 
+  This is really only a concern on a LAN, I think.
+
+  Because the purpose of this feature is to prevent mistakes, O_CREAT is not 
+  used. If the lock file doesn't already exist, it's possible the scan manager
+  is broken and trying to run wild. It is up to the scan manager to manage the
+  creation and deletion of the lock file and not the responsibility of masscan.
+
+  Exit if the lock file couldn't be opened
+  Exit if the fctnl(F_SETLK) failed
+
+  Return 0 if the lock was successful, application should continue
+
+  There is no unlock, we just let the lock die at process termination for 
+  simplicity. Note this short-circuits command line parsing.
+*/
+
+int
+acquire_posix_lock (const char *filename)
+{
+  struct flock fl = { F_WRLCK, SEEK_SET, 0, 0, 0 };
+  int fd;
+  int result = 0;
+
+  fl.l_pid = getpid ();
+
+  if ((fd = open (filename, O_RDWR)) == -1)
+    {
+      LOG(0,"FAIL: lock file can't be opened with errno message %s\n",strerror(errno));
+      exit(1);
+    }
+
+  if ((result = fcntl (fd, F_SETLK, &fl)) == -1)
+    {
+      if (errno == EAGAIN)
+	     {
+	       LOG (0, "FAIL: lock file %s is already locked by another process\n",filename);
+	     }
+      else
+	     { /* I don't know why this would ever happen unless some other application is messing with our lock */
+	       LOG (0, "FAIL: failed to acquire lock on file %s with errno message %s\n", filename,
+	       strerror (errno));
+	     }
+      exit(1);
+    }
+
+  return result;
+}
+#endif

--- a/src/posix-lock.h
+++ b/src/posix-lock.h
@@ -1,0 +1,8 @@
+#ifndef POSIX_LOCK_H
+#define POSIX_LOCK_H
+
+#if defined(__linux__) && defined(__GNUC__)
+int acquire_posix_lock (const char *filename);
+#endif
+
+#endif


### PR DESCRIPTION
of this is to prevent multiple instances of masscan from running
simultaneously (by accident) via an automated script. For example:

$ sudo masscan --range 10.0.0.0/8 \
               --ports 1-65535 \
               --rate 60000 \
               --lockfile /tmp/autoscan

This will have the effect of preventing another scan from running
when specifying the same lock file, assuming the initial scan is
still running / holding the lock.

This is useful when masscan is used with aggressive packet rates
on networks (LANs) that will melt if something goes awry and multiple
instances of the same scan kick off simultaneously, effectively
doubling (or tripling, etc.) the rate that packets are being sent.

This is a mitigation for edge cases in broken third party code, but
it seems like a simple enough feature to implement in the masscan
code itself.

The user has to obviously be aware of how to use the feature and
ensure that all invocations of masscan utilize the same lock file.

This is only tested on Linux, so it is only compiled in when the
__linux__ value is defined.