### PR TITLE
Fixed Unicornscan output so that 'closed' ports are reported as 'closed'

### DIFF
--- a/src/out-unicornscan.c
+++ b/src/out-unicornscan.c
@@ -80,7 +80,8 @@ unicornscan_out_status(struct Output *out, FILE *fp, time_t timestamp,
     UNUSEDPARM(timestamp);
 
     if (ip_proto == 6) {
-      fprintf(fp,"TCP open\t%16s[%5d]\t\tfrom %u.%u.%u.%u  ttl %-3d\n",
+      fprintf(fp,"TCP %s\t%16s[%5d]\t\tfrom %u.%u.%u.%u  ttl %-3d\n",
+              status_string(status),
               tcp_services[port],
               port,
               (ip>>24)&0xFF,


### PR DESCRIPTION
In the initial implementation, I accidentally left a hardcoded 'open' in
the fprintf, which made results for --show closed broken.