### PR TITLE
Fixed the boot status output to have correct information when an ICMP

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1256,10 +1256,22 @@ main_scan(struct Masscan *masscan)
         gmtime_s(&x, &now);
         strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S GMT", &x);
         LOG(0, "\nStarting masscan " MASSCAN_VERSION " (http://bit.ly/14GZzcT) at %s\n", buffer);
-        LOG(0, " -- forced options: -sS -Pn -n --randomize-hosts -v --send-eth\n");
-        LOG(0, "Initiating SYN Stealth Scan\n");
-        LOG(0, "Scanning %u hosts [%u port%s/host]\n",
-            (unsigned)count_ips, (unsigned)count_ports, (count_ports==1)?"":"s");
+
+        if (count_ports == 1 && \
+            masscan->ports.list->begin == Templ_ICMP_echo && \
+            masscan->ports.list->end == Templ_ICMP_echo)
+            { /* ICMP only */
+                LOG(0, " -- forced options: -sn -n --randomize-hosts -v --send-eth\n");
+                LOG(0, "Initiating ICMP Echo Scan\n");
+                LOG(0, "Scanning %u hosts\n",(unsigned)count_ips);
+             }
+        else /* This could actually also be a UDP only or mixed UDP/TCP/ICMP scan */
+            {
+                LOG(0, " -- forced options: -sS -Pn -n --randomize-hosts -v --send-eth\n");
+                LOG(0, "Initiating SYN Stealth Scan\n");
+                LOG(0, "Scanning %u hosts [%u port%s/host]\n",
+                    (unsigned)count_ips, (unsigned)count_ports, (count_ports==1)?"":"s");
+            }
     }
 
     /*


### PR DESCRIPTION
only scan is starting.

When performing a SYN scan, SYN + UDP scan, or SYN + UDP + ICMP scan,
the original behavior stays the same and reports a SYN Stealth scan.

This is just a cosmetic change to make it clearer that you didn't
invoke the scan incorrectly when trying to only perform a ping sweep.