### PR TITLE
Fix to make show = all in config files work correctly- which means sh…

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1374,6 +1374,11 @@ masscan_set_parameter(struct Masscan *masscan,
                 masscan->output.is_show_closed = 1;
             else if (EQUALSx("open", val2, val2_len))
                 masscan->output.is_show_host = 1;
+            else if (EQUALSx("all",val2,val2_len)) {
+                masscan->output.is_show_open = 1;
+                masscan->output.is_show_host = 1;
+                masscan->output.is_show_closed = 1;
+            }
             else {
                 LOG(0, "FAIL: unknown 'show' spec: %.*s\n", val2_len, val2);
                 exit(1);


### PR DESCRIPTION
Currently, using show = all in a config file throws an error saying
all is invalid. This fixes that.

things:

- Closed ports
- Open ports
- Up hosts

Note that the following two are equivalent in the config file:

show = open,closed,host
show = all

Note that the patch doesn't explicitly set

Pointed out by blkshv @ https://github.com/robertdavidgraham/masscan/issues/190

Addresses:
Gentoo bug @ https://bugs.gentoo.org/show_bug.cgi?id=503400